### PR TITLE
Add notes and untrusted domain patches

### DIFF
--- a/HideBloat/src/main/java/com/aliucord/plugins/HideBloat.java
+++ b/HideBloat/src/main/java/com/aliucord/plugins/HideBloat.java
@@ -23,7 +23,7 @@ public class HideBloat extends Plugin {
         var manifest = new Manifest();
         manifest.authors = new Manifest.Author[]{new Manifest.Author("Xinto", 423915768191647755L)};
         manifest.description = "Hides various discord bloat.";
-        manifest.version = "1.1.3";
+        manifest.version = "1.2.0";
         manifest.updateUrl = "https://raw.githubusercontent.com/X1nto/AliucordPlugins/builds/updater.json";
         return manifest;
     }

--- a/HideBloat/src/main/java/com/aliucord/plugins/hidebloat/patchers/NotesPatch.java
+++ b/HideBloat/src/main/java/com/aliucord/plugins/hidebloat/patchers/NotesPatch.java
@@ -1,0 +1,25 @@
+package com.aliucord.plugins.hidebloat.patchers;
+
+import com.aliucord.plugins.hidebloat.patchers.base.BasePatcher;
+import com.aliucord.plugins.hidebloat.util.Const;
+import com.aliucord.plugins.hidebloat.util.Util;
+import com.discord.databinding.WidgetUserSheetBinding;
+import com.discord.widgets.user.usersheet.WidgetUserSheet;
+import com.discord.widgets.user.usersheet.WidgetUserSheetViewModel;
+
+import top.canyie.pine.Pine;
+
+public class NotesPatch extends BasePatcher {
+    public NotesPatch() throws Exception {
+        super(Const.Key.NOTES_KEY, Const.ViewName.NOTES_NAME, WidgetUserSheet.class.getDeclaredMethod("configureNote", WidgetUserSheetViewModel.ViewState.Loaded.class));
+    }
+
+    @Override
+    public void patchBody(Pine.CallFrame callFrame) {
+        WidgetUserSheetBinding binding = WidgetUserSheet.access$getBinding$p((WidgetUserSheet) callFrame.thisObject);
+
+        Util.hideViewCompletely(binding.w);
+        Util.hideViewCompletely(binding.x);
+        Util.hideViewCompletely(binding.y);
+    }
+}

--- a/HideBloat/src/main/java/com/aliucord/plugins/hidebloat/patchers/UntrustedDomainPatch.java
+++ b/HideBloat/src/main/java/com/aliucord/plugins/hidebloat/patchers/UntrustedDomainPatch.java
@@ -1,0 +1,18 @@
+package com.aliucord.plugins.hidebloat.patchers;
+
+import com.aliucord.plugins.hidebloat.patchers.base.BasePatcher;
+import com.aliucord.plugins.hidebloat.util.Const;
+import com.discord.stores.StoreMaskedLinks;
+
+import top.canyie.pine.Pine;
+
+public class UntrustedDomainPatch extends BasePatcher {
+    public UntrustedDomainPatch() throws Exception {
+        super(Const.Key.UNTRUSTED_DOMAINS_KEY, Const.ViewName.UNTRUSTED_DOMAINS_NAME, StoreMaskedLinks.class.getDeclaredMethod("isTrustedDomain", String.class, String.class));
+    }
+
+    @Override
+    public void patchBody(Pine.CallFrame callFrame) {
+        callFrame.setResult(true);
+    }
+}

--- a/HideBloat/src/main/java/com/aliucord/plugins/hidebloat/util/Const.java
+++ b/HideBloat/src/main/java/com/aliucord/plugins/hidebloat/util/Const.java
@@ -10,6 +10,8 @@ public class Const {
         public static final String INVITE_BUTTON_CHANNELS_KEY = "channelInviteButton";
         public static final String INVITE_BUTTON_MEMBERS_KEY = "memberInviteButton";
         public static final String SEARCH_BOX_KEY = "searchBoxDM";
+        public static final String NOTES_KEY = "notes";
+        public static final String UNTRUSTED_DOMAINS_KEY = "untrustedDomains";
     }
     
     public static class ViewName {
@@ -18,8 +20,7 @@ public class Const {
         public static final String INVITE_BUTTON_CHANNELS_NAME = "Invite button in channels list";
         public static final String INVITE_BUTTON_MEMBERS_NAME = "Invite button in members list";
         public static final String SEARCH_BOX_NAME = "Search box in DM list";
+        public static final String NOTES_NAME = "Notes on user sheet";
+        public static final String UNTRUSTED_DOMAINS_NAME = "Untrusted domain prompt";
     }
-
-    
-
 }

--- a/HideBloat/src/main/java/com/aliucord/plugins/hidebloat/util/Util.java
+++ b/HideBloat/src/main/java/com/aliucord/plugins/hidebloat/util/Util.java
@@ -8,6 +8,8 @@ import com.aliucord.plugins.hidebloat.patchers.ChannelsInviteButtonPatch;
 import com.aliucord.plugins.hidebloat.patchers.DmSearchBoxPatch;
 import com.aliucord.plugins.hidebloat.patchers.MembersInviteButtonPatch;
 import com.aliucord.plugins.hidebloat.patchers.NitroGiftButtonPatch;
+import com.aliucord.plugins.hidebloat.patchers.NotesPatch;
+import com.aliucord.plugins.hidebloat.patchers.UntrustedDomainPatch;
 import com.aliucord.plugins.hidebloat.patchers.base.BasePatcher;
 
 public class Util {
@@ -21,7 +23,9 @@ public class Util {
                     new ChannelsInviteButtonPatch(),
                     new DmSearchBoxPatch(),
                     new MembersInviteButtonPatch(),
-                    new NitroGiftButtonPatch()
+                    new NitroGiftButtonPatch(),
+                    new NotesPatch(),
+                    new UntrustedDomainPatch()
             };
         } catch (Exception ignored) {}
     }

--- a/HideBloat/src/main/java/com/discord/databinding/WidgetUserSheetBinding.java
+++ b/HideBloat/src/main/java/com/discord/databinding/WidgetUserSheetBinding.java
@@ -1,6 +1,10 @@
 package com.discord.databinding;
 
 import android.widget.Button;
+import android.widget.TextView;
+
+import com.google.android.material.textfield.TextInputEditText;
+import com.google.android.material.textfield.TextInputLayout;
 
 public class WidgetUserSheetBinding {
 
@@ -14,4 +18,18 @@ public class WidgetUserSheetBinding {
      */
     public Button J;
 
+    /**
+     * Notes header
+     */
+    public TextView w;
+
+    /**
+     * Notes text
+     */
+    public TextInputEditText x;
+
+    /**
+     * Notes text wrap
+     */
+    public TextInputLayout y;
 }

--- a/HideBloat/src/main/java/com/discord/stores/StoreMaskedLinks.java
+++ b/HideBloat/src/main/java/com/discord/stores/StoreMaskedLinks.java
@@ -1,0 +1,3 @@
+package com.discord.stores;
+
+public class StoreMaskedLinks { }

--- a/updater.json
+++ b/updater.json
@@ -15,7 +15,7 @@
     "version": "1.0.1"
   },
   "HideBloat": {
-    "version": "1.1.3"
+    "version": "1.2.3"
   },
   "default": {
     "version": "1.0.0",

--- a/updater.json
+++ b/updater.json
@@ -15,7 +15,7 @@
     "version": "1.0.1"
   },
   "HideBloat": {
-    "version": "1.2.3"
+    "version": "1.2.0"
   },
   "default": {
     "version": "1.0.0",


### PR DESCRIPTION
Adds a patch for the notes on user sheets and a patch for the pop up when clicking on an untrusted link. For the hide untrusted domain prompt it would be better on performance to use method replacement.