### PR TITLE
Update default Emote Size

### DIFF
--- a/plugins/NitroSpoof/src/main/java/com/aliucord/plugins/nitrospoof/Util.kt
+++ b/plugins/NitroSpoof/src/main/java/com/aliucord/plugins/nitrospoof/Util.kt
@@ -1,4 +1,4 @@
 package com.aliucord.plugins.nitrospoof
 
-const val EMOTE_SIZE_DEFAULT = "40"
+const val EMOTE_SIZE_DEFAULT = "48"
 const val EMOTE_SIZE_KEY = "emote_size"


### PR DESCRIPTION
In a more recent update the service discord uses to supply these images got expanded so it now supports ?size=48  (60 was also added and a couple more)