### PR TITLE
feat(LayoutController): dm wave patch

### DIFF
--- a/plugins/LayoutController/README.md
+++ b/plugins/LayoutController/README.md
@@ -9,4 +9,5 @@ Lets you control the discord mobile layout.
 - Hide the notes box in the user sheet
 - Hide the call buttons in the user sheet
 - Remove the "Untrusted Domain" dialog
-- Removes the welcome sticker button on join messages
+- Remove the welcome sticker button on join messages
+- Remove the Wave button in blank DMs

--- a/plugins/LayoutController/build.gradle.kts
+++ b/plugins/LayoutController/build.gradle.kts
@@ -1,5 +1,5 @@
 description = "Lets you control the discord mobile layout."
-version = "1.0.2"
+version = "1.0.4"
 
 aliucord {
     author("zt", 289556910426816513L)

--- a/plugins/LayoutController/src/main/java/com/xinto/aliuplugins/layoutcontroller/patchers/DMWavePatch.kt
+++ b/plugins/LayoutController/src/main/java/com/xinto/aliuplugins/layoutcontroller/patchers/DMWavePatch.kt
@@ -1,0 +1,24 @@
+package com.xinto.aliuplugins.layoutcontroller.patchers
+
+import com.discord.widgets.chat.list.adapter.WidgetChatListAdapterItemStickerGreet
+import com.discord.widgets.chat.list.entries.ChatListEntry
+import com.xinto.aliuplugins.layoutcontroller.patchers.base.BasePatcher
+import com.xinto.aliuplugins.layoutcontroller.util.Description
+import com.xinto.aliuplugins.layoutcontroller.util.Key
+import com.xinto.aliuplugins.layoutcontroller.util.hideCompletely
+import de.robv.android.xposed.XC_MethodHook
+
+class DMWavePatch : BasePatcher(
+    key = Key.DM_WAVE_KEY,
+    description = Description.DM_WAVE_DESCRIPTION,
+    classMember = WidgetChatListAdapterItemStickerGreet::class.java.getDeclaredMethod(
+        "onConfigure",
+        Int::class.javaPrimitiveType,
+        ChatListEntry::class.java
+    ),
+) {
+    override fun patchBody(callFrame: XC_MethodHook.MethodHookParam) {
+        val thisObj = callFrame.thisObject as WidgetChatListAdapterItemStickerGreet
+        thisObj.itemView.hideCompletely()
+    }
+}

--- a/plugins/LayoutController/src/main/java/com/xinto/aliuplugins/layoutcontroller/util/Const.kt
+++ b/plugins/LayoutController/src/main/java/com/xinto/aliuplugins/layoutcontroller/util/Const.kt
@@ -11,6 +11,7 @@ object Key {
     const val NOTES_KEY = "notes"
     const val UNTRUSTED_DOMAINS_KEY = "untrustedDomains"
     const val WELCOME_BUTTON_KEY = "welcomeButton"
+    const val DM_WAVE_KEY = "dmWelcomeButton"
 }
 
 object Description {
@@ -22,4 +23,5 @@ object Description {
     const val NOTES_DESCRIPTION = "Remove the notes box from the user sheet"
     const val UNTRUSTED_DOMAINS_DESCRIPTION = "Remove the untrusted domain dialog"
     const val WELCOME_BUTTON_DESCRIPTION = "Remove the welcome button on join messages"
+    const val DM_WAVE_DESCRIPTION = "Remove the Wave button in blank DMs"
 }

--- a/plugins/LayoutController/src/main/java/com/xinto/aliuplugins/layoutcontroller/util/Util.kt
+++ b/plugins/LayoutController/src/main/java/com/xinto/aliuplugins/layoutcontroller/util/Util.kt
@@ -13,6 +13,7 @@ val patches = arrayOf(
     NotesPatch(),
     UntrustedDomainPatch(),
     WelcomeButtonPatch(),
+    DMWavePatch(),
 )
 
 fun View.hideCompletely() {


### PR DESCRIPTION
Hides the wave btn container in blank DMs
![Screenshot_20211111-075908](https://user-images.githubusercontent.com/33725716/141329190-90564925-0ed3-49d9-8bf7-1b8eccd690e3.png)

