### PR TITLE
add freeCompilerArgs that disable useless checks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,10 @@ subprojects {
         tasks.withType<KotlinCompile> {
             kotlinOptions {
                 jvmTarget = "11"
+                freeCompilerArgs = freeCompilerArgs +
+                    "-Xno-call-assertions" +
+                    "-Xno-param-assertions" +
+                    "-Xno-receiver-assertions"
             }
         }
     }


### PR DESCRIPTION
This will disable useless Intrinsics checks that only slow down plugins
![image](https://user-images.githubusercontent.com/31005896/154167853-32047cc9-c18c-4cba-8bb9-feb407d34ee7.png)
