### PR TITLE
[Nitro Spoof] Add emote name to emote url

### DIFF
--- a/plugins/NitroSpoof/src/main/java/com/xinto/aliuplugins/NitroSpoof.kt
+++ b/plugins/NitroSpoof/src/main/java/com/xinto/aliuplugins/NitroSpoof.kt
@@ -62,11 +62,12 @@ class NitroSpoof : Plugin() {
 
         val idStr = thisObject.getCachedField<String>("idStr")
         val isAnimated = thisObject.getCachedField<Boolean>("isAnimated")
+        val emoteName = thisObject.getCachedField<String>("name")
 
         finalUrl += idStr
         val emoteSize = settings.getString(EMOTE_SIZE_KEY, EMOTE_SIZE_DEFAULT).toIntOrNull()
 
-        finalUrl += (if (isAnimated) ".gif" else ".png") + "?quality=lossless"
+        finalUrl += (if (isAnimated) ".gif" else ".png") + "?quality=lossless&name=" + emoteName
 
         if (emoteSize != null) {
             finalUrl += "&size=${emoteSize}"


### PR DESCRIPTION
This makes it play nicely with Vencord's Transform Emojis option by showing the emoji's name (instead of just falling back to FakeNitroEmoji) without messing with how it shows on Aliucord (which doesn't support hyperlink markdown for example).