### PR TITLE
[Nitro Spoof] Fix unavailable emotes when boost level runs out

### DIFF
--- a/plugins/NitroSpoof/src/main/java/com/xinto/aliuplugins/NitroSpoof.kt
+++ b/plugins/NitroSpoof/src/main/java/com/xinto/aliuplugins/NitroSpoof.kt
@@ -52,8 +52,9 @@ class NitroSpoof : Plugin() {
     private fun getChatReplacement(callFrame: XC_MethodHook.MethodHookParam) {
         val thisObject = callFrame.thisObject as ModelEmojiCustom
         val isUsable = thisObject.getCachedField<Boolean>("isUsable")
+        val available = thisObject.getCachedField<Boolean>("available")
 
-        if (isUsable) {
+        if (isUsable && available) {
             callFrame.result = callFrame.result
             return
         }


### PR DESCRIPTION
Previously if emotes were unavailable due to the server boost level running out, NitroSpoof would behave as if they were still usable, for example when trying to use a static unavailable emote in the same server it was uploaded to.

This also makes the plugin useful for Nitro users as emotes unavailable due to lack of boost aren't usable even with Nitro.